### PR TITLE
added code for fetching hmbd and LIPIDMAPS dbs

### DIFF
--- a/metabolinks/create_local_dbs.py
+++ b/metabolinks/create_local_dbs.py
@@ -18,6 +18,35 @@ this file is used to generate trans_hmdb2kegg.txt.
 
 """
 
+
+#Fetch and extract online data bases' .zip files
+def fetch_db(url, file_name):
+    import requests
+    from zipfile import ZipFile
+    # download the file contents in binary format
+    r = requests.get(url)
+    # open method to open a file on your system and write the contents
+    with open(file_name, "wb") as f:
+        f.write(r.content)
+
+    # opening the zip file in READ mode 
+    with ZipFile(file_name, 'r') as zip: 
+        # printing all the contents of the zip file 
+        zip.printdir() 
+  
+        # extracting all the files 
+        print('Extracting all the files now...') 
+        zip.extractall() 
+        print('Done!')
+
+print('Fetching hmbd...')
+fetch_db('http://www.hmdb.ca/system/downloads/current/hmdb_metabolites.zip', 'hmbd_db.zip')
+print('Fetching LIPIDMAPS...')
+fetch_db('http://www.lipidmaps.org/resources/downloads/LMSDFDownload12Dec17.zip', 'LIPIDMAPS_db.zip')
+
+
+#---------------------------------
+
 import xml.etree.ElementTree as ET
 import zipfile
 from six import StringIO


### PR DESCRIPTION
Boa noite professor, 
Como combinado está aqui a função que vai buscar as bases de dados online do hmbd e LIPIDMAPS. Não consegui aplicá-la também ao ChEBI porque a plataforma só diponibiliza a bd no formato .gzip e a função não consegue extrair os ficheiros (porque obtenho um zip com outro zip lá dentro). Não sei se devia tentar converter o .gzip em .zip, ou qual seria a alternativa...

Atentamente,
Beatriz Lima


